### PR TITLE
Added config option to disable map blips

### DIFF
--- a/SPAII Setting/frmSPA.Designer.vb
+++ b/SPAII Setting/frmSPA.Designer.vb
@@ -107,6 +107,7 @@ Partial Class frmSPA
         Me.tcTab = New System.Windows.Forms.TabControl()
         Me.tpSettings = New System.Windows.Forms.TabPage()
         Me.GroupBox4 = New System.Windows.Forms.GroupBox()
+        Me.cbDebug = New System.Windows.Forms.CheckBox()
         Me.cbMission = New System.Windows.Forms.CheckBox()
         Me.cbOnlineMap = New System.Windows.Forms.CheckBox()
         Me.tpAptToggle = New System.Windows.Forms.TabPage()
@@ -151,7 +152,7 @@ Partial Class frmSPA
         Me.txtSPA1 = New System.Windows.Forms.TextBox()
         Me.cmbSPA1 = New System.Windows.Forms.ComboBox()
         Me.Label9 = New System.Windows.Forms.Label()
-        Me.cbDebug = New System.Windows.Forms.CheckBox()
+        Me.cbDisableBlips = New System.Windows.Forms.CheckBox()
         Me.gbApt.SuspendLayout()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.gbGarage.SuspendLayout()
@@ -1159,15 +1160,26 @@ Partial Class frmSPA
         '
         'GroupBox4
         '
+        Me.GroupBox4.Controls.Add(Me.cbDisableBlips)
         Me.GroupBox4.Controls.Add(Me.cbDebug)
         Me.GroupBox4.Controls.Add(Me.cbMission)
         Me.GroupBox4.Controls.Add(Me.cbOnlineMap)
         Me.GroupBox4.Location = New System.Drawing.Point(6, 59)
         Me.GroupBox4.Name = "GroupBox4"
-        Me.GroupBox4.Size = New System.Drawing.Size(361, 94)
+        Me.GroupBox4.Size = New System.Drawing.Size(361, 121)
         Me.GroupBox4.TabIndex = 1
         Me.GroupBox4.TabStop = False
         Me.GroupBox4.Text = "Setting"
+        '
+        'cbDebug
+        '
+        Me.cbDebug.AutoSize = True
+        Me.cbDebug.Location = New System.Drawing.Point(6, 72)
+        Me.cbDebug.Name = "cbDebug"
+        Me.cbDebug.Size = New System.Drawing.Size(95, 19)
+        Me.cbDebug.TabIndex = 2
+        Me.cbDebug.Text = "Debug Mode"
+        Me.cbDebug.UseVisualStyleBackColor = True
         '
         'cbMission
         '
@@ -1331,6 +1343,7 @@ Partial Class frmSPA
         Me.lvBuilding.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.chPropName, Me.chPropIntName, Me.chPropOwner, Me.chPropStyle})
         Me.lvBuilding.FullRowSelect = True
         Me.lvBuilding.GridLines = True
+        Me.lvBuilding.HideSelection = False
         Me.lvBuilding.Location = New System.Drawing.Point(6, 6)
         Me.lvBuilding.MultiSelect = False
         Me.lvBuilding.Name = "lvBuilding"
@@ -1437,6 +1450,7 @@ Partial Class frmSPA
         Me.lvSPA2.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.chName2, Me.chPlate2, Me.chFile2})
         Me.lvSPA2.FullRowSelect = True
         Me.lvSPA2.GridLines = True
+        Me.lvSPA2.HideSelection = False
         Me.lvSPA2.Location = New System.Drawing.Point(77, 80)
         Me.lvSPA2.Name = "lvSPA2"
         Me.lvSPA2.Size = New System.Drawing.Size(703, 161)
@@ -1540,6 +1554,7 @@ Partial Class frmSPA
         Me.lvSPA1.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.chName1, Me.chPlate1, Me.chFIle1})
         Me.lvSPA1.FullRowSelect = True
         Me.lvSPA1.GridLines = True
+        Me.lvSPA1.HideSelection = False
         Me.lvSPA1.Location = New System.Drawing.Point(77, 80)
         Me.lvSPA1.Name = "lvSPA1"
         Me.lvSPA1.Size = New System.Drawing.Size(703, 163)
@@ -1591,15 +1606,15 @@ Partial Class frmSPA
         Me.Label9.TabIndex = 5
         Me.Label9.Text = "Apartment"
         '
-        'cbDebug
+        'cbDisableBlips
         '
-        Me.cbDebug.AutoSize = True
-        Me.cbDebug.Location = New System.Drawing.Point(6, 72)
-        Me.cbDebug.Name = "cbDebug"
-        Me.cbDebug.Size = New System.Drawing.Size(95, 19)
-        Me.cbDebug.TabIndex = 2
-        Me.cbDebug.Text = "Debug Mode"
-        Me.cbDebug.UseVisualStyleBackColor = True
+        Me.cbDisableBlips.AutoSize = True
+        Me.cbDisableBlips.Location = New System.Drawing.Point(6, 97)
+        Me.cbDisableBlips.Name = "cbDisableBlips"
+        Me.cbDisableBlips.Size = New System.Drawing.Size(119, 19)
+        Me.cbDisableBlips.TabIndex = 3
+        Me.cbDisableBlips.Text = "Disable Map Blips"
+        Me.cbDisableBlips.UseVisualStyleBackColor = True
         '
         'frmSPA
         '
@@ -1774,4 +1789,5 @@ Partial Class frmSPA
     Friend WithEvents Label17 As Label
     Friend WithEvents txtPropName As TextBox
     Friend WithEvents cbDebug As CheckBox
+    Friend WithEvents cbDisableBlips As CheckBox
 End Class

--- a/SPAII Setting/frmSPA.vb
+++ b/SPAII Setting/frmSPA.vb
@@ -52,6 +52,11 @@
         Catch ex As Exception
             cbDebug.Checked = False
         End Try
+        Try
+            cbDisableBlips.Checked = CBool(ReadIniValue(config, "SETTING", "DisableBlips"))
+        Catch ex As Exception
+            cbDisableBlips.Checked = False
+        End Try
 
         'Load Vehicle Transfers
         txtSPA1.Text = IO.Path.GetFullPath("..\SinglePlayerApartment\Garage")
@@ -107,6 +112,7 @@
             WriteIniValue(config, "SETTING", "OnlineMap", cbOnlineMap.Checked)
             WriteIniValue(config, "SETTING", "HideBlipsOnMission", cbMission.Checked)
             WriteIniValue(config, "SETTING", "DebugMode", cbDebug.Checked)
+            WriteIniValue(config, "SETTING", "DisableBlips", cbDisableBlips.Checked)
 
             For Each item As ListViewItem In lvBuilding.Items
                 Dim itemTag As Tuple(Of String, String, String, String, Integer) = item.Tag

--- a/SPAII/Class/ConfigHelper.vb
+++ b/SPAII/Class/ConfigHelper.vb
@@ -7,6 +7,7 @@ Module ConfigHelper
 
     Public DebugMode As Boolean = False
     Public OnlineMap As Boolean = True
+    Public DisableBlips As Boolean = False
     Public SoundVolume As Integer = 100
 
     Public Sub LoadModConfig()
@@ -15,6 +16,7 @@ Module ConfigHelper
         SoundVolume = config.GetValue(Of Integer)("SOUND", "Volume", 100)
         DebugMode = config.GetValue(Of Boolean)("SETTING", "DebugMode", False)
         OnlineMap = config.GetValue(Of Boolean)("SETTING", "OnlineMap", True)
+        DisableBlips = config.GetValue(Of Boolean)("SETTING", "DisableBlips", True)
     End Sub
 
     Public Sub GenerateModConfig()
@@ -26,6 +28,7 @@ Module ConfigHelper
             config.SetValue(Of Boolean)("SETTING", "OnlineMap", True)
             config.SetValue(Of Boolean)("SETTING", "HideBlipsOnMission", True)
             config.SetValue(Of Boolean)("SETTING", "DebugMode", False)
+            config.SetValue(Of Boolean)("SETTING", "DisableBlips", False)
 
             Dim cutProp() As Integer = {82, 88, 91, 93}
             For i As Integer = 1 To 95

--- a/SPAII/Class/Database/BuildingClass.vb
+++ b/SPAII/Class/Database/BuildingClass.vb
@@ -47,7 +47,6 @@ Public Class BuildingClass
     Public WithEvents GrgMenu As UIMenu
 
     Public Sub New()
-
     End Sub
 
     Public Function IsVacant() As Boolean
@@ -56,93 +55,95 @@ Public Class BuildingClass
     End Function
 
     Public Sub Load()
-        If Not IsVacant() AndAlso Not BuildingType = eBuildingType.Garage Then
-            GarageBlip = World.CreateBlip(GarageInPos)
-            With GarageBlip
-                .IsShortRange = True
-                .Sprite = BlipSprite.Garage
-                .Name = Game.GetGXTEntry("BLIP_357")
-                .Color = GetBlipColor
-            End With
-        End If
 
-        BuildingBlip = World.CreateBlip(BuildingInPos.ToVector3)
-        With BuildingBlip
-            .IsShortRange = True
-            If IsVacant() Then
-                If Not DebugMode Then
-                    Select Case BuildingType
-                        Case eBuildingType.Apartment
-                            .Sprite = BlipSprite.SafehouseForSale
-                            .Name = Game.GetGXTEntry("MP_PROP_SALE1") 'Apartment For Sale
-                        Case eBuildingType.Office
-                            .Sprite = BlipSprite.OfficeForSale
-                            .Name = Game.GetGXTEntry("MP_PROP_SALE2") 'Office For Sale
-                        Case eBuildingType.ClubHouse, eBuildingType.NightClub, eBuildingType.Bunker
-                            .Sprite = BlipSprite.BusinessForSale
-                            .Name = Game.GetGXTEntry("BLIP_373") 'Property For Sale
-                        Case eBuildingType.Garage
-                            .Sprite = BlipSprite.GarageForSale
-                            .Name = Game.GetGXTEntry("MP_PROP_SALE0") 'Garage For Sale
-                        Case eBuildingType.Hangar
-                            .Sprite = BlipSprite.HangarForSale
-                            .Name = Game.GetGXTEntry("BLIP_372") 'Hangar For Sale
-                        Case eBuildingType.Warehouse
-                            .Sprite = BlipSprite.WarehouseForSale
-                            .Name = Game.GetGXTEntry("BLIP_474") 'Warehouse For Sale
-                    End Select
+        If Not DisableBlips Then
+            If Not IsVacant() AndAlso Not BuildingType = eBuildingType.Garage Then
+                GarageBlip = World.CreateBlip(GarageInPos)
+                With GarageBlip
+                    .IsShortRange = True
+                    .Sprite = BlipSprite.Garage
+                    .Name = Game.GetGXTEntry("BLIP_357")
+                    .Color = GetBlipColor
+                End With
+            End If
+            BuildingBlip = World.CreateBlip(BuildingInPos.ToVector3)
+            With BuildingBlip
+                .IsShortRange = True
+                If IsVacant() Then
+                    If Not DebugMode Then
+                        Select Case BuildingType
+                            Case eBuildingType.Apartment
+                                .Sprite = BlipSprite.SafehouseForSale
+                                .Name = Game.GetGXTEntry("MP_PROP_SALE1") 'Apartment For Sale
+                            Case eBuildingType.Office
+                                .Sprite = BlipSprite.OfficeForSale
+                                .Name = Game.GetGXTEntry("MP_PROP_SALE2") 'Office For Sale
+                            Case eBuildingType.ClubHouse, eBuildingType.NightClub, eBuildingType.Bunker
+                                .Sprite = BlipSprite.BusinessForSale
+                                .Name = Game.GetGXTEntry("BLIP_373") 'Property For Sale
+                            Case eBuildingType.Garage
+                                .Sprite = BlipSprite.GarageForSale
+                                .Name = Game.GetGXTEntry("MP_PROP_SALE0") 'Garage For Sale
+                            Case eBuildingType.Hangar
+                                .Sprite = BlipSprite.HangarForSale
+                                .Name = Game.GetGXTEntry("BLIP_372") 'Hangar For Sale
+                            Case eBuildingType.Warehouse
+                                .Sprite = BlipSprite.WarehouseForSale
+                                .Name = Game.GetGXTEntry("BLIP_474") 'Warehouse For Sale
+                        End Select
+                    Else
+                        Select Case BuildingType
+                            Case eBuildingType.Apartment
+                                .Sprite = BlipSprite.Safehouse
+                            Case eBuildingType.Office
+                                .Sprite = BlipSprite.Office
+                            Case eBuildingType.ClubHouse
+                                .Sprite = BlipSprite.BikerClubhouse
+                            Case eBuildingType.Garage
+                                .Sprite = BlipSprite.Garage
+                            Case eBuildingType.Hangar
+                                .Sprite = BlipSprite.GTAOHangar
+                            Case eBuildingType.NightClub
+                                .Sprite = BlipSprite.NightclubProperty
+                            Case eBuildingType.Warehouse
+                                .Sprite = BlipSprite.Warehouse
+                            Case eBuildingType.Bunker
+                                .Sprite = BlipSprite.Bunker
+                        End Select
+                        .Name = Name
+                    End If
+                    .Color = BlipColor.White
                 Else
                     Select Case BuildingType
                         Case eBuildingType.Apartment
                             .Sprite = BlipSprite.Safehouse
+                            .Name = Game.GetGXTEntry("CELL_2630")
                         Case eBuildingType.Office
                             .Sprite = BlipSprite.Office
+                            .Name = Game.GetGXTEntry("BLIP_475")
                         Case eBuildingType.ClubHouse
                             .Sprite = BlipSprite.BikerClubhouse
+                            .Name = Game.GetGXTEntry("PM_SPAWN_CLUBH")
                         Case eBuildingType.Garage
                             .Sprite = BlipSprite.Garage
+                            .Name = Game.GetGXTEntry("BLIP_357")
                         Case eBuildingType.Hangar
                             .Sprite = BlipSprite.GTAOHangar
+                            .Name = Game.GetGXTEntry("BLIP_359")
                         Case eBuildingType.NightClub
                             .Sprite = BlipSprite.NightclubProperty
+                            .Name = Game.GetGXTEntry("CELL_CLUB")
                         Case eBuildingType.Warehouse
                             .Sprite = BlipSprite.Warehouse
+                            .Name = Game.GetGXTEntry("BLIP_473")
                         Case eBuildingType.Bunker
                             .Sprite = BlipSprite.Bunker
+                            .Name = Game.GetGXTEntry("BLIP_557")
                     End Select
-                    .Name = Name
+                    .Color = GetBlipColor
                 End If
-                .Color = BlipColor.White
-            Else
-                Select Case BuildingType
-                    Case eBuildingType.Apartment
-                        .Sprite = BlipSprite.Safehouse
-                        .Name = Game.GetGXTEntry("CELL_2630")
-                    Case eBuildingType.Office
-                        .Sprite = BlipSprite.Office
-                        .Name = Game.GetGXTEntry("BLIP_475")
-                    Case eBuildingType.ClubHouse
-                        .Sprite = BlipSprite.BikerClubhouse
-                        .Name = Game.GetGXTEntry("PM_SPAWN_CLUBH")
-                    Case eBuildingType.Garage
-                        .Sprite = BlipSprite.Garage
-                        .Name = Game.GetGXTEntry("BLIP_357")
-                    Case eBuildingType.Hangar
-                        .Sprite = BlipSprite.GTAOHangar
-                        .Name = Game.GetGXTEntry("BLIP_359")
-                    Case eBuildingType.NightClub
-                        .Sprite = BlipSprite.NightclubProperty
-                        .Name = Game.GetGXTEntry("CELL_CLUB")
-                    Case eBuildingType.Warehouse
-                        .Sprite = BlipSprite.Warehouse
-                        .Name = Game.GetGXTEntry("BLIP_473")
-                    Case eBuildingType.Bunker
-                        .Sprite = BlipSprite.Bunker
-                        .Name = Game.GetGXTEntry("BLIP_557")
-                End Select
-                .Color = GetBlipColor
-            End If
-        End With
+            End With
+        End If
 
         BuyMenu = New UIMenu("", Game.GetGXTEntry("MP_PROP_GEN0"), New Point(0, -107))
         BuyMenu.SetBannerType(MenuBanner)
@@ -369,6 +370,10 @@ Public Class BuildingClass
     End Sub
 
     Public Sub RefreshBlips()
+        If DisableBlips Then
+            Return
+        End If
+
         If Not IsVacant() AndAlso Not BuildingType = eBuildingType.Garage Then
             GarageBlip = World.CreateBlip(GarageInPos)
             With GarageBlip
@@ -715,7 +720,7 @@ Public Class BuildingClass
                                 BuyMenu.Visible = False
                                 FadeScreen(1)
                                 Player.Money = (PM - apt.Price)
-                                BuildingBlip.Remove()
+                                If Not BuildingBlip Is Nothing Then BuildingBlip.Remove()
                                 If Not GarageBlip Is Nothing Then GarageBlip.Remove()
                                 RefreshBuyMenu()
                                 RefreshAptMenu()
@@ -736,7 +741,7 @@ Public Class BuildingClass
                             apt.UpdateApartmentOwner()
                             BuyMenu.Visible = False
                             FadeScreen(1)
-                            BuildingBlip.Remove()
+                            If Not BuildingBlip Is Nothing Then BuildingBlip.Remove()
                             If Not GarageBlip Is Nothing Then GarageBlip.Remove()
                             RefreshBuyMenu()
                             RefreshAptMenu()

--- a/SPAII/Class/Garage/Mechanic.vb
+++ b/SPAII/Class/Garage/Mechanic.vb
@@ -304,7 +304,7 @@ Module Mechanic
                     Dynasty8BuyMenu.Visible = False
                     iFruit.Close()
                     With bld
-                        .BuildingBlip.Remove()
+                        If Not .BuildingBlip Is Nothing Then .BuildingBlip.Remove()
                         If Not .GarageBlip Is Nothing Then .GarageBlip.Remove()
                         .RefreshBuyMenu()
                         .RefreshAptMenu()
@@ -321,7 +321,7 @@ Module Mechanic
                 Dynasty8BuyMenu.Visible = False
                 iFruit.Close()
                 With bld
-                    .BuildingBlip.Remove()
+                    If Not .BuildingBlip Is Nothing Then .BuildingBlip.Remove()
                     If Not .GarageBlip Is Nothing Then .GarageBlip.Remove()
                     .RefreshBuyMenu()
                     .RefreshAptMenu()
@@ -341,7 +341,7 @@ Module Mechanic
         Dynasty8TradeMenu.Visible = False
         iFruit.Close()
         With bld
-            .BuildingBlip.Remove()
+            If Not .BuildingBlip Is Nothing Then .BuildingBlip.Remove()
             If Not .GarageBlip Is Nothing Then .GarageBlip.Remove()
             .RefreshBuyMenu()
             .RefreshAptMenu()

--- a/SPAII/SPA2.vb
+++ b/SPAII/SPA2.vb
@@ -157,7 +157,7 @@ Public Class SPA2
                     End If
 
                     'Hide Blips on Mission
-                    If config.GetValue(Of Boolean)("SETTING", "HideBlipsOnMission", True) Then
+                    If Not DisableBlips And config.GetValue(Of Boolean)("SETTING", "HideBlipsOnMission", True) Then
                         If Game.MissionFlag Then
                             If bd.BuildingBlip.Alpha = 255 Then bd.BuildingBlip.Alpha = 0
                             If bd.GarageBlip <> Nothing Then If bd.GarageBlip.Alpha = 255 Then bd.GarageBlip.Alpha = 0
@@ -212,7 +212,7 @@ Public Class SPA2
     Private Sub SPA2_Aborted(sender As Object, e As EventArgs) Handles Me.Aborted
         For Each Building In buildings
             If Building.SaleSignProp <> Nothing Then Building.SaleSignProp.Delete()
-            Building.BuildingBlip.Remove()
+            If Not Building.BuildingBlip = Nothing Then Building.BuildingBlip.Remove()
             If Not Building.GarageBlip = Nothing Then Building.GarageBlip.Remove()
         Next
 


### PR DESCRIPTION
I wanted to use properties and the mechanic in my modded single player, play through.  However, due to the number of blips, single player mission blips get removed.

This PR adds a config option that will disable map blips.  This make its harder to find apartments to buy, but still allows you to buy them. Players can use a map outside of the game to find them if need be.  While this is not ideal, it still allows me to use this mod in single player, without this change. I wouldn't be able to use the mod. 

You'll see in the commit I disable blips, and then check for Nothing everywhere to make sure it doesn't error. 
